### PR TITLE
Fix scene activation for PowerView Hub 2.0

### DIFF
--- a/PowerView.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/PowerView.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -69,8 +69,12 @@ class Plugin(indigo.PluginBase):
         data = self.powerview.shade(hubHostname, shadeId)
         data.pop('name') # don't overwrite local changes
 
+        # update the shade state for items in the device.
+        # PV2 hubs have at least one additional data item
+        # (signalStrengh) not in the device definition
         for key, value in data.iteritems():
-            shade.updateStateOnServer(key, value)
+            if key in shade.states:
+                shade.updateStateOnServer(key, value)
 
     def createShade(self, hubHostname, shadeId):
         address = '%s:%s' % (hubHostname, shadeId)

--- a/PowerView.indigoPlugin/Contents/Server Plugin/powerview.py
+++ b/PowerView.indigoPlugin/Contents/Server Plugin/powerview.py
@@ -5,7 +5,7 @@ import urllib2
 class PowerView:
     def activateScene(self, hubHostname, sceneId):
         activateSceneUrl = \
-                'http://%s/api/scenes?sceneid=%s' % (hubHostname, sceneId)
+                'http://%s/api/scenes?sceneId=%s' % (hubHostname, sceneId)
 
         self.__GET(activateSceneUrl)
 


### PR DESCRIPTION
For PowerView Hub 2.0, the scene activation URL needs to be "?sceneId=" instead of "?sceneid=".  I don't have a 1.0 version to test with to know if this is backward compatible or if fixing this properly will require detecting the version of the hub.